### PR TITLE
Fixing event handler names in code sample in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ window.onload = function() {
       config={config} 
       annotations={annotations} 
       onCreateAnnotation={onCreateAnnotation} 
-      onUpdateAnnotation={onCreateAnnotation} 
-      onDeleteAnnotation={onCreateAnnotation} />,
+      onUpdateAnnotation={onUpdateAnnotation} 
+      onDeleteAnnotation={onDeleteAnnotation} />,
     document.getElementById('app')
   );
     


### PR DESCRIPTION
This pull request corrects a code sample in the readme.md file. The previous code had I think incorrect event handler names (onCreateAnnotation, onUpdateAnnotation, and onDeleteAnnotation were all set to onCreateAnnotation). This update corrects the names of the event handlers according to their respective functions.

### Changes made
- Corrected event handler names in the code snippet.
- Replaced "onCreateAnnotation" with "onUpdateAnnotation" and "onDeleteAnnotation" in the appropriate places.